### PR TITLE
[FEATURE] Clean up "About Us" page #157613717

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -97,10 +97,10 @@
 
       <div class="center wow fadeInDown">
         <h2>About XenoDATA Partners</h2>
-        <p class="lead">XenoData is a boutique management consulting firm partnering with you on making your data strategy successful. We
+        <p class="lead section-description">XenoData is a boutique management consulting firm partnering with you on making your data strategy successful. We
           strive to understand your core data issues through a business lens and partner with leading technology providers
           to achieve these goals both in an implementation and advisory capacity.
-          <p class="lead">Companies cannot afford haphazard multimillion dollar investments in technologies that do not produce results.
+          <p class="lead section-description">Companies cannot afford haphazard multimillion dollar investments in technologies that do not produce results.
             Xenodata works to empower these teams with the right strategies and technologies to derive business benefit and
             winning strategies with their data.</p>
       </div>
@@ -108,45 +108,46 @@
       <div class="skill-wrap clearfix team">
         <div class="center wow fadeInDown">
           <h2>Leadership Team</h2>
-          <p class="lead"></p>
         </div>
 
-        <div class="col-md-6 col-lg-4">
-          <div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
-            <div class="media">
-              <div class="pull-left">
-                <a href="#">
-                  <img class="media-object" src="images/advisors/taylor.jpg" alt="">
-                </a>
+        <div class="row leadership-team">
+          <div class="col-md-12 col-lg-8">
+            <div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
+              <div class="media">
+                <div class="pull-left">
+                  <a href="#">
+                    <img class="media-object" src="images/advisors/taylor.jpg" alt="">
+                  </a>
+                </div>
+                <div class="media-body">
+                  <h4>Taylor Culver</h4>
+                  <h5>Founder &amp; Principal Consultant XenoDATA Partners</h5>
+                  <ul class="tag clearfix">
+                    <li class="btn">
+                      <a href="#">Data Strategy</a>
+                    </li>
+                    <li class="btn">
+                      <a href="#">Corporate Finance</a>
+                    </li>
+                    <li class="btn">
+                      <a href="#">Business Intelligence</a>
+                    </li>
+                  </ul>
+                  <ul class="social_icons">
+                    <li>
+                      <a href="https://www.linkedin.com/in/taylorculver/">
+                        <i class="fa fa-linkedin"></i>
+                      </a>
+                    </li>
+                  </ul>
+                </div>
               </div>
-              <div class="media-body">
-                <h4>Taylor Culver</h4>
-                <h5>Founder &amp; Principal Consultant XenoDATA Partners</h5>
-                <ul class="tag clearfix">
-                  <li class="btn">
-                    <a href="#">Data Strategy</a>
-                  </li>
-                  <li class="btn">
-                    <a href="#">Corporate Finance</a>
-                  </li>
-                  <li class="btn">
-                    <a href="#">Business Intelligence</a>
-                  </li>
-                </ul>
-                <ul class="social_icons">
-                  <li>
-                    <a href="https://www.linkedin.com/in/taylorculver/">
-                      <i class="fa fa-linkedin"></i>
-                    </a>
-                  </li>
-                </ul>
-              </div>
+              <!--/.media -->
+              <p>Taylor Culver has spent the past 10 years developing an expertise in leveraging data across the enterprise.
+                Across multiple successful projects across multiple industries, Taylor has lead successful strategic intiatives
+                and have implemented technologies that have solved critical operational, financial, and client issues while
+                raising the bar for organizational strategy and managing data as a strategic asset.</p>
             </div>
-            <!--/.media -->
-            <p>Taylor Culver has spent the past 10 years developing an expertise in leveraging data across the enterprise. Across
-              multiple successful projects across multiple industries, Taylor has lead successful strategic intiatives and
-              have implemented technologies that have solved critical operational, financial, and client issues while raising
-              the bar for organizational strategy and managing data as a strategic asset.</p>
           </div>
         </div>
       </div>
@@ -154,266 +155,241 @@
 
       <!-- our-team -->
       <div class="team">
-        <div class="center wow fadeInDown">
+        <div class="advisory-header center wow fadeInDown">
           <h2>Advisory Board</h2>
-          <p class="lead">XenoDATA Partners are proud to bring in house advice that spans multiple domains and industries, all unified by
+          <p class="lead section-description">XenoDATA Partners are proud to bring in house advice that spans multiple domains and industries, all unified by
             a passion for solving organizational issues with data.</p>
         </div>
 
-        <div class="col-md-6 col-lg-4">
-          <div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
-            <div class="media">
-              <div class="pull-left">
-                <a href="#">
-                  <img class="media-object" src="images/advisors/ozel.jpg" alt="">
-                </a>
+        <div class="row advisory-row">
+          <div class="col-md-12 col-lg-4">
+            <div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
+              <div class="media">
+                <div class="pull-left">
+                  <a href="#">
+                    <img class="media-object" src="images/advisors/ozel.jpg" alt="">
+                  </a>
+                </div>
+                <div class="media-body">
+                  <h4>Ozel Christo</h4>
+                  <h5>CEO &amp; Founder of Neokami</h5>
+                  <ul class="tag clearfix">
+                    <li class="btn">
+                      <a href="#">Artificial Inteligence</a>
+                    </li>
+                    <li class="btn">
+                      <a href="#">Machine Learning</a>
+                    </li>
+                    <li class="btn">
+                      <a href="#">Data Visualization</a>
+                    </li>
+                  </ul>
+                  <ul class="social_icons">
+                    <li>
+                      <a href="https://www.linkedin.com/in/ozelchristo/">
+                        <i class="fa fa-linkedin"></i>
+                      </a>
+                    </li>
+                    <li>
+                      <a href="https://twitter.com/ozelchristo?lang=en">
+                        <i class="fa fa-twitter"></i>
+                      </a>
+                    </li>
+                  </ul>
+                </div>
               </div>
-              <div class="media-body">
-                <h4>Ozel Christo</h4>
-                <h5>CEO &amp; Founder of Neokami</h5>
-                <ul class="tag clearfix">
-                  <li class="btn">
-                    <a href="#">Artificial Inteligence</a>
-                  </li>
-                  <li class="btn">
-                    <a href="#">Machine Learning</a>
-                  </li>
-                  <li class="btn">
-                    <a href="#">Data Visualization</a>
-                  </li>
-                </ul>
-                <ul class="social_icons">
-                  <li>
-                    <a href="https://www.linkedin.com/in/ozelchristo/">
-                      <i class="fa fa-linkedin"></i>
-                    </a>
-                  </li>
-                  <li>
-                    <a href="https://twitter.com/ozelchristo?lang=en">
-                      <i class="fa fa-twitter"></i>
-                    </a>
-                  </li>
-                </ul>
-              </div>
+              <!--/.media -->
+              <p>Experienced entrepreneur and computer scientist. Prior to founding Neokami, studied Computational Science and
+                Engineering at the Technical University of Munich and worked as a machine learning software developer at
+                several start-ups. Ozel has 17 years of algorithm design, coding and implementation experience.</p>
             </div>
-            <!--/.media -->
-            <p>Experienced entrepreneur and computer scientist. Prior to founding Neokami, studied Computational Science and
-              Engineering at the Technical University of Munich and worked as a machine learning software developer at several
-              start-ups. Ozel has 17 years of algorithm design, coding and implementation experience.</p>
+          </div>
+
+          <div class="col-md-12 col-lg-4">
+            <div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
+              <div class="media">
+                <div class="pull-left">
+                  <a href="#">
+                    <img class="media-object" src="images/advisors/reuben.jpg" alt="">
+                  </a>
+                </div>
+                <div class="media-body">
+                  <h4>Reuben Vandeventer</h4>
+                  <h5>Founder &amp; CEO Data Clairvoyance</h5>
+                  <ul class="tag clearfix">
+                    <li class="btn">
+                      <a href="#">Data Monetization</a>
+                    </li>
+                    <li class="btn">
+                      <a href="#">Data Strategy</a>
+                    </li>
+                    <li class="btn">
+                      <a href="#">Data Governance</a>
+                    </li>
+                  </ul>
+                  <ul class="social_icons">
+                    <li>
+                      <a href="https://www.linkedin.com/in/ozelchristo/">
+                        <i class="fa fa-linkedin"></i>
+                      </a>
+                    </li>
+                    <li>
+                      <a href="https://twitter.com/rjvandeve?lang=en">
+                        <i class="fa fa-twitter"></i>
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <!--/.media -->
+              <p>Mr. Vandeventer has been driving progress and helping to shape the data space for more than a decade, across
+                many industries including Medical Device, Pharmaceutical, Insurance and Asset Management. His background
+                in science, statistics and finance has created a robust foundation to create real economic value for organizations
+                in new and innovative ways.</p>
+            </div>
+          </div>
+
+          <div class="col-md-12 col-lg-4">
+            <div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
+              <div class="media">
+                <div class="pull-left">
+                  <a href="http://innerpowerintl.com/debbie-himsel/">
+                    <img class="media-object" src="images/advisors/debbie.jpg" alt="">
+                  </a>
+                </div>
+                <div class="media-body">
+                  <h4>Deborah Himsel</h4>
+                  <h5>President Himsel &amp; and Associates</h5>
+                  <ul class="tag clearfix">
+                    <li class="btn">
+                      <a href="#">Change Management</a>
+                    </li>
+                    <li class="btn">
+                      <a href="#">Executive Coaching</a>
+                    </li>
+                    <li class="btn">
+                      <a href="#">Organizational Developement</a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <!--/.media -->
+              <p>Deborrah M. Himsel is a recognized expert in leadership development, a change agent, a thought leader, an author,
+                an educator and executive coach…a sought-after speaker for conferences and workshops.</p>
+            </div>
           </div>
         </div>
 
-        <div class="col-md-6 col-lg-4">
-          <div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
-            <div class="media">
-              <div class="pull-left">
-                <a href="#">
-                  <img class="media-object" src="images/advisors/reuben.jpg" alt="">
-                </a>
+        <div class="row advisory-row">
+
+          <div class="col-md-12 col-lg-4">
+            <div class="single-profile-bottom wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
+              <div class="media">
+                <div class="pull-left">
+                  <a href="#">
+                    <img class="media-object" src="images/advisors/bill.jpg" alt="">
+                  </a>
+                </div>
+                <div class="media-body">
+                  <h4>William D. Gilbride, Jr.</h4>
+                  <h5>Managing Shareholder and CEO at Abbott Nicholson</h5>
+                  <ul class="tag clearfix">
+                    <li class="btn">
+                      <a href="#">Corporate Law</a>
+                    </li>
+                    <li class="btn">
+                      <a href="#">Dispute Avoidance</a>
+                    </li>
+                    <li class="btn">
+                      <a href="#">Conflict Resolution</a>
+                    </li>
+                  </ul>
+                  <ul class="social_icons">
+                    <li>
+                      <a href="https://www.linkedin.com/in/william-d-gilbride-jr-b9636a1a/">
+                        <i class="fa fa-linkedin"></i>
+                      </a>
+                    </li>
+                  </ul>
+                </div>
               </div>
-              <div class="media-body">
-                <h4>Reuben Vandeventer</h4>
-                <h5>Founder &amp; CEO Data Clairvoyance</h5>
-                <ul class="tag clearfix">
-                  <li class="btn">
-                    <a href="#">Data Monetization</a>
-                  </li>
-                  <li class="btn">
-                    <a href="#">Data Strategy</a>
-                  </li>
-                  <li class="btn">
-                    <a href="#">Data Governance</a>
-                  </li>
-                </ul>
-                <ul class="social_icons">
-                  <li>
-                    <a href="https://www.linkedin.com/in/ozelchristo/">
-                      <i class="fa fa-linkedin"></i>
-                    </a>
-                  </li>
-                  <li>
-                    <a href="https://twitter.com/rjvandeve?lang=en">
-                      <i class="fa fa-twitter"></i>
-                    </a>
-                  </li>
-                </ul>
-              </div>
+              <!--/.media -->
+              <p>Bill has over 30 years of experience representing business interests in contracts, business and corporate law,
+                dispute avoidance and resolution, real estate, zoning and land use law. Bill has been approved as outside
+                counsel for Ascension Health; Amazon; Kettering University; Northern Trust Bank; Rockwell Automation; SmithGroupJJR;
+                St John Providence Health System; and US Bank.</p>
             </div>
-            <!--/.media -->
-            <p>Mr. Vandeventer has been driving progress and helping to shape the data space for more than a decade, across
-              many industries including Medical Device, Pharmaceutical, Insurance and Asset Management. His background in
-              science, statistics and finance has created a robust foundation to create real economic value for organizations
-              in new and innovative ways.</p>
+          </div>
+
+          <div class="col-md-12 col-lg-4">
+            <div class="single-profile-bottom wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
+              <div class="media">
+                <div class="pull-left">
+                  <a href="#">
+                    <img class="media-object" src="images/advisors/kyle.jpg" alt="">
+                  </a>
+                </div>
+                <div class="media-body">
+                  <h4>Kyle Scott</h4>
+                  <h5>Vice President, Finance at HercRentals</h5>
+                  <ul class="tag clearfix">
+                    <li class="btn">
+                      <a href="#">Corporate Finance</a>
+                    </li>
+                    <li class="btn">
+                      <a href="#">FP&amp;A</a>
+                    </li>
+                    <li class="btn">
+                      <a href="#">Operations</a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <!--/.media -->
+              <p>Current Vice President of Finance and former CFO of Hertz Europe, Kyle is a leader in driving sales and operational
+                results with data.</p>
+            </div>
+          </div>
+
+          <div class="col-md-12 col-lg-4">
+            <div class="single-profile-bottom wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
+              <div class="media">
+                <div class="pull-left">
+                  <a href="#">
+                    <img class="media-object" src="images/advisors/tristan.jpg" alt="">
+                  </a>
+                </div>
+                <div class="media-body">
+                  <h4>Tristan Blakely</h4>
+                  <h5>Founder, Dreamtek &amp; Partner @ The Virtual Forge</h5>
+                  <ul class="tag clearfix">
+                    <li class="btn">
+                      <a href="#">Content Production</a>
+                    </li>
+                    <li class="btn">
+                      <a href="#">Marketing</a>
+                    </li>
+                    <li class="btn">
+                      <a href="#">Product Development</a>
+                    </li>
+                  </ul>
+
+                  <ul class="social_icons">
+                    <li>
+                      <a href="https://www.linkedin.com/in/tristan-blakley-361a545/">
+                        <i class="fa fa-linkedin"></i>
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <!--/.media -->
+              <p>Tech entrepreneur specialising in providing data-centric solutions for large enterprise &amp; StartUps leveraging
+                Artificial Intelligence &amp; Machine Learning</p>
+            </div>
           </div>
         </div>
-
-        <div class="col-md-6 col-lg-4">
-          <div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
-            <div class="media">
-              <div class="pull-left">
-                <a href="http://innerpowerintl.com/debbie-himsel/">
-                  <img class="media-object" src="images/advisors/debbie.jpg" alt="">
-                </a>
-              </div>
-              <div class="media-body">
-                <h4>Deborah Himsel</h4>
-                <h5>President Himsel &amp; and Associates</h5>
-                <ul class="tag clearfix">
-                  <li class="btn">
-                    <a href="#">Change Management</a>
-                  </li>
-                  <li class="btn">
-                    <a href="#">Executive Coaching</a>
-                  </li>
-                  <li class="btn">
-                    <a href="#">Organizational Developement</a>
-                  </li>
-                </ul>
-
-                <ul class="social_icons">
-                  <li>
-                    <a href="#">
-                      <i class="fa fa-linkedin"></i>
-                    </a>
-                  </li>
-                  <li>
-                    <a href="#">
-                      <i class="fa fa-twitter"></i>
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            </div>
-            <!--/.media -->
-            <p>Deborrah M. Himsel is a recognized expert in leadership development, a change agent, a thought leader, an author,
-              an educator and executive coach…a sought-after speaker for conferences and workshops.</p>
-          </div>
-        </div>
-
-        <div class="col-md-6 col-lg-4">
-          <div class="single-profile-bottom wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
-            <div class="media">
-              <div class="pull-left">
-                <a href="#">
-                  <img class="media-object" src="images/advisors/bill.jpg" alt="">
-                </a>
-              </div>
-              <div class="media-body">
-                <h4>William D. Gilbride, Jr.</h4>
-                <h5>Managing Shareholder and CEO at Abbott Nicholson</h5>
-                <ul class="tag clearfix">
-                  <li class="btn">
-                    <a href="#">Corporate Law</a>
-                  </li>
-                  <li class="btn">
-                    <a href="#">Dispute Avoidance</a>
-                  </li>
-                  <li class="btn">
-                    <a href="#">Conflict Resolution</a>
-                  </li>
-                </ul>
-                <ul class="social_icons">
-                  <li>
-                    <a href="https://www.linkedin.com/in/william-d-gilbride-jr-b9636a1a/">
-                      <i class="fa fa-linkedin"></i>
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            </div>
-            <!--/.media -->
-            <p>Bill has over 30 years of experience representing business interests in contracts, business and corporate law,
-              dispute avoidance and resolution, real estate, zoning and land use law. Bill has been approved as outside counsel
-              for Ascension Health; Amazon; Kettering University; Northern Trust Bank; Rockwell Automation; SmithGroupJJR;
-              St John Providence Health System; and US Bank.</p>
-          </div>
-        </div>
-
-        <div class="col-md-6 col-lg-4">
-          <div class="single-profile-bottom wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
-            <div class="media">
-              <div class="pull-left">
-                <a href="#">
-                  <img class="media-object" src="images/advisors/kyle.jpg" alt="">
-                </a>
-              </div>
-              <div class="media-body">
-                <h4>Kyle Scott</h4>
-                <h5>Vice President, Finance at HercRentals</h5>
-                <ul class="tag clearfix">
-                  <li class="btn">
-                    <a href="#">Corporate Finance</a>
-                  </li>
-                  <li class="btn">
-                    <a href="#">FP&amp;A</a>
-                  </li>
-                  <li class="btn">
-                    <a href="#">Operations</a>
-                  </li>
-                </ul>
-
-                <ul class="social_icons">
-                  <li>
-                    <a href="#">
-                      <i class="fa fa-linkedin"></i>
-                    </a>
-                  </li>
-                  <li>
-                    <a href="#">
-                      <i class="fa fa-twitter"></i>
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            </div>
-            <!--/.media -->
-            <p>Current Vice President of Finance and former CFO of Hertz Europe, Kyle is a leader in driving sales and operational
-              results with data.</p>
-          </div>
-        </div>
-
-        <div class="col-md-6 col-lg-4">
-          <div class="single-profile-bottom wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
-            <div class="media">
-              <div class="pull-left">
-                <a href="#">
-                  <img class="media-object" src="images/advisors/tristan.jpg" alt="">
-                </a>
-              </div>
-              <div class="media-body">
-                <h4>Tristan Blakely</h4>
-                <h5>Founder, Dreamtek &amp; Partner @ The Virtual Forge</h5>
-                <ul class="tag clearfix">
-                  <li class="btn">
-                    <a href="#">Content Production</a>
-                  </li>
-                  <li class="btn">
-                    <a href="#">Marketing</a>
-                  </li>
-                  <li class="btn">
-                    <a href="#">Product Development</a>
-                  </li>
-                </ul>
-
-                <ul class="social_icons">
-                  <li>
-                    <a href="https://www.linkedin.com/in/tristan-blakley-361a545/">
-                      <i class="fa fa-linkedin"></i>
-                    </a>
-                  </li>
-                  <li>
-                    <a href="#">
-                      <i class="fa fa-twitter"></i>
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            </div>
-            <!--/.media -->
-            <p>Tech entrepreneur specialising in providing data-centric solutions for large enterprise &amp; StartUps leveraging
-              Artificial Intelligence &amp; Machine Learning</p>
-          </div>
-        </div>
+        <!--advisory board row 2 -->
 
       </div>
       <!--Team -->

--- a/about-us.html
+++ b/about-us.html
@@ -1,338 +1,516 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="">
-    <meta name="author" content="">
-    <title>XenoDATA Partners</title>
 
-    <!-- core CSS -->
-    <link href="css/bootstrap.min.css" rel="stylesheet">
-    <link href="css/font-awesome.min.css" rel="stylesheet">
-    <link href="css/animate.min.css" rel="stylesheet">
-    <link href="css/prettyPhoto.css" rel="stylesheet">
-    <link href="css/main.css" rel="stylesheet">
-    <link href="css/responsive.css" rel="stylesheet">
-    <!--[if lt IE 9]>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="">
+  <meta name="author" content="">
+  <title>XenoDATA Partners</title>
+
+  <!-- core CSS -->
+  <link href="css/bootstrap.min.css" rel="stylesheet">
+  <link href="css/font-awesome.min.css" rel="stylesheet">
+  <link href="css/animate.min.css" rel="stylesheet">
+  <link href="css/prettyPhoto.css" rel="stylesheet">
+  <link href="css/main.css" rel="stylesheet">
+  <link href="css/responsive.css" rel="stylesheet">
+  <!--[if lt IE 9]>
     <script src="js/html5shiv.js"></script>
     <script src="js/respond.min.js"></script>
     <![endif]-->
-    <link rel="shortcut icon" href="images/ico/xenodata_logo_shortcut.ico">
-</head><!--/head-->
+  <link rel="shortcut icon" href="images/ico/xenodata_logo_shortcut.ico">
+</head>
+<!--/head-->
 
 <body class="homepage">
 
-    <header id="header">
-        <div class="top-bar">
-            <div class="container">
-                <div class="row">
-                    <div class="col-xs-6">
-                        <div class="top-number"><p><i class="fa fa-phone-square"></i>  +1 866-907-6620</p></div>
-                    </div>
-                    <div class="col-xs-6">
-                       <div class="social">
-                            <ul class="social-share">
-                                <li><a href="https://www.linkedin.com/company/xenodatapartners/"><i class="fa fa-linkedin"></i></a></li>
-                            </ul>
-                       </div>
-                    </div>
-                </div>
-            </div><!--/.container-->
-        </div><!--/.top-bar-->
-
-        <nav class="navbar navbar-default" role="banner">
-            <div class="container">
-                <div class="navbar-header">
-                    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-                        <span class="sr-only">Toggle navigation</span>
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                    </button>
-                    <a class="navbar-brand" href="index.html"><img src="images/xenodata_logo.png" alt="logo"></a>
-                </div>
-
-                <div class="collapse navbar-collapse navbar-right">
-                    <ul class="nav navbar-nav">
-                        <li><a href="index.html">Home</a></li>
-                        <li class="active"><a href="about-us.html">About Us</a></li>
-                        <li><a href="services.html">Services</a></li>
-                        <li><a href="partners.html">Partners</a></li>
-                        <li><a href="contact-us.html">Contact</a></li>
-                    </ul>
-                </div>
-            </div><!--/.container-->
-        </nav><!--/nav-->
-    </header><!--/header-->
-
-    <section id="about-us.html">
-        <div class="container">
-			<div class="center wow fadeInDown">
-				<h2>About XenoDATA Partners</h2>
-				<p class="lead">XenoData is a boutique management consulting firm partnering with you on making your data strategy successful. We strive to understand your core data issues through a business lens and partner with leading technology providers to achieve these goals both in an implementation and advisory capacity.
-				<p class="lead">Companies cannot afford haphazard multimillion dollar investments in technologies that do not produce results. Xenodata works to empower these teams with the right strategies and technologies to derive business benefit and winning strategies with their data.</p>
-			</div>
-
-			<div class="skill-wrap clearfix team">
-
-				<div class="center wow fadeInDown">
-					<h2>Leadership Team</h2>
-					<p class="lead"></p>
-				</div>
-				<div class="col-md-6 col-lg-4" >
-		          	<div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms" >
-		          		<div class="media">
-							<div class="pull-left">
-								<a href="#"><img class="media-object" src="images/advisors/taylor.jpg" alt=""></a>
-							</div>
-							<div class="media-body">
-								<h4>Taylor Culver</h4>
-								<h5>Founder &amp; Principal Consultant XenoDATA Partners</h5>
-								<ul class="tag clearfix">
-									<li class="btn"><a href="#">Data Strategy</a></li>
-									<li class="btn"><a href="#">Corporate Finance</a></li>
-									<li class="btn"><a href="#">Business Intelligence</a></li>
-								</ul>
-
-								<ul class="social_icons">
-									<li><a href="https://www.linkedin.com/in/taylorculver/"><i class="fa fa-linkedin"></i></a></li>
-									<!-- <li><a href="https://twitter.com/ozelchristo?lang=en"><i class="fa fa-twitter"></i></a></li>  -->
-<!-- 									<li><a href="#"><i class="fa fa-google-plus"></i></a></li> -->
-								</ul>
-							</div>
-						</div><!--/.media -->
-						<p>Taylor Culver has spent the past 10 years developing an expertise in leveraging data across the enterprise. Across multiple successful projects across multiple industries, Taylor has lead successful strategic intiatives and have implemented technologies that have solved critical operational, financial, and client issues while raising the bar for organizational strategy and managing data as a strategic asset.</p>
-		          </div>
-		       	</div>
-
-            </div><!--/.our-skill-->
-
-
-			<!-- our-team -->
-			<div class="team">
-				<div class="center wow fadeInDown">
-					<h2>Advisory Board</h2>
-					<p class="lead">XenoDATA Partners are proud to bring in house advice that spans multiple domains and industries, all unified by a passion for solving organizational issues with data.</p>
-				</div>
-
-		        <div class="col-md-6 col-lg-4">
-		          	<div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
-		          		<div class="media">
-							<div class="pull-left">
-								<a href="#"><img class="media-object" src="images/advisors/ozel.jpg" alt=""></a>
-							</div>
-							<div class="media-body">
-								<h4>Ozel Christo</h4>
-								<h5>CEO &amp; Founder of Neokami</h5>
-								<ul class="tag clearfix">
-									<li class="btn"><a href="#">Artificial Inteligence</a></li>
-									<li class="btn"><a href="#">Machine Learning</a></li>
-									<li class="btn"><a href="#">Data Visualization</a></li>
-								</ul>
-
-								<ul class="social_icons">
-									<li><a href="https://www.linkedin.com/in/ozelchristo/"><i class="fa fa-linkedin"></i></a></li>
-									<li><a href="https://twitter.com/ozelchristo?lang=en"><i class="fa fa-twitter"></i></a></li>
-<!-- 									<li><a href="#"><i class="fa fa-google-plus"></i></a></li> -->
-								</ul>
-							</div>
-						</div><!--/.media -->
-						<p>Experienced entrepreneur and computer scientist. Prior to founding Neokami, studied Computational Science and Engineering at the Technical University of Munich and worked as a machine learning software developer at several start-ups. Ozel has 17 years of algorithm design, coding and implementation experience.</p>
-		          </div>
-		       	</div>
-
-		        <div class="col-md-6 col-lg-4">
-		          	<div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
-		          		<div class="media">
-							<div class="pull-left">
-								<a href="#"><img class="media-object" src="images/advisors/reuben.jpg" alt=""></a>
-							</div>
-							<div class="media-body">
-								<h4>Reuben Vandeventer</h4>
-								<h5>Founder &amp; CEO Data Clairvoyance</h5>
-								<ul class="tag clearfix">
-									<li class="btn"><a href="#">Data Monetization</a></li>
-									<li class="btn"><a href="#">Data Strategy</a></li>
-									<li class="btn"><a href="#">Data Governance</a></li>
-								</ul>
-
-								<ul class="social_icons">
-									<li><a href="https://www.linkedin.com/in/ozelchristo/"><i class="fa fa-linkedin"></i></a></li>
-									<li><a href="https://twitter.com/rjvandeve?lang=en"><i class="fa fa-twitter"></i></a></li>
-									<!--<li><a href="#"><i class="fa fa-google-plus"></i></a></li> -->
-								</ul>
-							</div>
-						</div><!--/.media -->
-						<p>Mr. Vandeventer has been driving progress and helping to shape the data space for more than a decade, across many industries including Medical Device, Pharmaceutical, Insurance and Asset Management. His background in science, statistics and finance has created a robust foundation to create real economic value for organizations in new and innovative ways.</p>
-		          </div>
-		       	</div>
-
-		        <div class="col-md-6 col-lg-4">
-		          	<div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
-		          		<div class="media">
-							<div class="pull-left">
-								<a href="http://innerpowerintl.com/debbie-himsel/"><img class="media-object" src="images/advisors/debbie.jpg" alt=""></a>
-							</div>
-							<div class="media-body">
-								<h4>Deborah Himsel</h4>
-								<h5>President Himsel &amp; and Associates</h5>
-								<ul class="tag clearfix">
-									<li class="btn"><a href="#">Change Management</a></li>
-									<li class="btn"><a href="#">Executive Coaching</a></li>
-									<li class="btn"><a href="#">Organizational Developement</a></li>
-								</ul>
-
-								<ul class="social_icons">
-									<li><a href="#"><i class="fa fa-linkedin"></i></a></li>
-									<li><a href="#"><i class="fa fa-twitter"></i></a></li>
-									<!--<li><a href="#"><i class="fa fa-google-plus"></i></a></li> -->
-								</ul>
-							</div>
-						</div><!--/.media -->
-						<p>Deborrah M. Himsel is a recognized expert in leadership development, a change agent, a thought leader, an author, an educator and executive coach…a sought-after speaker for conferences and workshops.</p>
-		          </div>
-		       	</div>
-
-		        <div class="col-md-6 col-lg-4">
-		          	<div class="single-profile-bottom wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
-		          		<div class="media">
-							<div class="pull-left">
-								<a href="#"><img class="media-object" src="images/advisors/bill.jpg" alt=""></a>
-							</div>
-							<div class="media-body">
-								<h4>William D. Gilbride, Jr.</h4>
-								<h5>Managing Shareholder and CEO at Abbott Nicholson</h5>
-								<ul class="tag clearfix">
-									<li class="btn"><a href="#">Corporate Law</a></li>
-									<li class="btn"><a href="#">Dispute Avoidance</a></li>
-									<li class="btn"><a href="#">Conflict Resolution</a></li>
-								</ul>
-
-								<ul class="social_icons">
-									<li><a href="https://www.linkedin.com/in/william-d-gilbride-jr-b9636a1a/"><i class="fa fa-linkedin"></i></a></li>
-									<!-- <li><a href="https://twitter.com/rjvandeve?lang=en"><i class="fa fa-twitter"></i></a></li>  -->
-									<!--<li><a href="#"><i class="fa fa-google-plus"></i></a></li> -->
-								</ul>
-							</div>
-						</div><!--/.media -->
-						<p>Bill has over 30 years of experience representing business interests in contracts, business and corporate law, dispute avoidance and resolution, real estate, zoning and land use law. Bill has been approved as outside counsel for Ascension Health; Amazon; Kettering University; Northern Trust Bank; Rockwell Automation; SmithGroupJJR; St John Providence Health System; and US Bank.</p>
-		          </div>
-		       	</div>
-
-		        <div class="col-md-6 col-lg-4">
-		          	<div class="single-profile-bottom wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
-		          		<div class="media">
-							<div class="pull-left">
-								<a href="#"><img class="media-object" src="images/advisors/kyle.jpg" alt=""></a>
-							</div>
-							<div class="media-body">
-								<h4>Kyle Scott</h4>
-								<h5>Vice President, Finance at HercRentals</h5>
-								<ul class="tag clearfix">
-									<li class="btn"><a href="#">Corporate Finance</a></li>
-									<li class="btn"><a href="#">FP&amp;A</a></li>
-									<li class="btn"><a href="#">Operations</a></li>
-								</ul>
-
-								<ul class="social_icons">
-									<li><a href="#"><i class="fa fa-linkedin"></i></a></li>
-									<li><a href="#"><i class="fa fa-twitter"></i></a></li>
-									<!--<li><a href="#"><i class="fa fa-google-plus"></i></a></li> -->
-								</ul>
-							</div>
-						</div><!--/.media -->
-						<p>Current Vice President of Finance and former CFO of Hertz Europe, Kyle is a leader in driving sales and operational results with data.</p>
-		          </div>
-		       	</div>
-
-		        <div class="col-md-6 col-lg-4">
-		          	<div class="single-profile-bottom wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
-		          		<div class="media">
-							<div class="pull-left">
-								<a href="#"><img class="media-object" src="images/advisors/tristan.jpg" alt=""></a>
-							</div>
-							<div class="media-body">
-								<h4>Tristan Blakely</h4>
-								<h5>Founder, Dreamtek &amp; Partner @ The Virtual Forge</h5>
-								<ul class="tag clearfix">
-									<li class="btn"><a href="#">Content Production</a></li>
-									<li class="btn"><a href="#">Marketing</a></li>
-									<li class="btn"><a href="#">Product Development</a></li>
-								</ul>
-
-								<ul class="social_icons">
-									<li><a href="https://www.linkedin.com/in/tristan-blakley-361a545/"><i class="fa fa-linkedin"></i></a></li>
-									<li><a href="#"><i class="fa fa-twitter"></i></a></li>
-									<!--<li><a href="#"><i class="fa fa-google-plus"></i></a></li> -->
-								</ul>
-							</div>
-						</div><!--/.media -->
-						<p>Tech entrepreneur specialising in providing data-centric solutions for large enterprise &amp; StartUps leveraging Artificial Intelligence &amp; Machine Learning</p>
-		          </div>
-		       	</div>
-    </section><!--/about-us.html-->
-
-    <section id="bottom">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-3 col-xs-12">
-                    <div class="widget">
-                        <h3>Company</h3>
-                        <ul>
-                            <li><a href="about-us.html">About Us</a></li>
-                            <li><a href="about-us.html">Meet the Team</a></li>
-                            <li><a href="contact-us.html">Contact Us</a></li>
-                        </ul>
-                    </div>
-                </div><!--/.col-md-3-->
-
-                <div class="col-md-3 col-xs-12">
-                    <div class="widget">
-                        <h3>Services</h3>
-                        <ul>
-                            <li><a href="services.html">Overview</a></li>
-                            <li><a href="services.html">Methodology</a></li>
-                            <li><a href="services.html">Client Personas</a></li>
-                        </ul>
-                    </div>
-                </div><!--/.col-md-3-->
-
-                <div class="col-md-3 col-xs-12">
-                    <div class="widget">
-                        <h3>Our Partners</h3>
-                        <ul>
-                            <li><a href="partners.html">The Virtual Forge</a></li>
-                            <li><a href="partners.html">ThoughtSpot</a></li>
-                        </ul>
-                    </div>
-                </div><!--/.col-md-3-->
+  <header id="header">
+    <div class="top-bar">
+      <div class="container">
+        <div class="row">
+          <div class="col-xs-6">
+            <div class="top-number">
+              <p>
+                <i class="fa fa-phone-square"></i> +1 866-907-6620</p>
             </div>
-        </div>
-    </section><!--/#bottom-->
-
-    <footer id="footer" class="midnight-blue">
-        <div class="container">
-            <div class="row">
-                <div class="col-sm-6">
-                    &copy; 2018 <a target="_blank" href="http://shapebootstrap.net/" title="Free Twitter Bootstrap WordPress Themes and HTML templates">Culver Global Holdings</a>. All Rights Reserved.
-                </div>
-                <div class="col-sm-6">
-                    <ul class="pull-right">
-                        <li><a href="index.html">Home</a></li>
-                        <li><a href="about-us.html">About Us</a></li>
-                        <li><a href="contact-us.html">Contact Us</a></li>
-                    </ul>
-                </div>
+          </div>
+          <div class="col-xs-6">
+            <div class="social">
+              <ul class="social-share">
+                <li>
+                  <a href="https://www.linkedin.com/company/xenodatapartners/">
+                    <i class="fa fa-linkedin"></i>
+                  </a>
+                </li>
+              </ul>
             </div>
+          </div>
         </div>
-    </footer><!--/#footer-->
+      </div>
+      <!--/.container-->
+    </div>
+    <!--/.top-bar-->
 
-    <script src="js/jquery.js"></script>
-    <script src="js/bootstrap.min.js"></script>
-    <script src="js/jquery.prettyPhoto.js"></script>
-    <script src="js/jquery.isotope.min.js"></script>
-    <script src="js/main.js"></script>
-    <script src="js/wow.min.js"></script>
+    <nav class="navbar navbar-default" role="banner">
+      <div class="container">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="navbar-brand" href="index.html">
+            <img src="images/xenodata_logo.png" alt="logo">
+          </a>
+        </div>
+
+        <div class="collapse navbar-collapse navbar-right">
+          <ul class="nav navbar-nav">
+            <li>
+              <a href="index.html">Home</a>
+            </li>
+            <li class="active">
+              <a href="about-us.html">About Us</a>
+            </li>
+            <li>
+              <a href="services.html">Services</a>
+            </li>
+            <li>
+              <a href="partners.html">Partners</a>
+            </li>
+            <li>
+              <a href="contact-us.html">Contact</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <!--/.container-->
+    </nav>
+    <!--/nav-->
+  </header>
+  <!--/header-->
+
+  <section id="about-us.html">
+    <div class="container">
+
+      <div class="center wow fadeInDown">
+        <h2>About XenoDATA Partners</h2>
+        <p class="lead">XenoData is a boutique management consulting firm partnering with you on making your data strategy successful. We
+          strive to understand your core data issues through a business lens and partner with leading technology providers
+          to achieve these goals both in an implementation and advisory capacity.
+          <p class="lead">Companies cannot afford haphazard multimillion dollar investments in technologies that do not produce results.
+            Xenodata works to empower these teams with the right strategies and technologies to derive business benefit and
+            winning strategies with their data.</p>
+      </div>
+
+      <div class="skill-wrap clearfix team">
+        <div class="center wow fadeInDown">
+          <h2>Leadership Team</h2>
+          <p class="lead"></p>
+        </div>
+
+        <div class="col-md-6 col-lg-4">
+          <div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
+            <div class="media">
+              <div class="pull-left">
+                <a href="#">
+                  <img class="media-object" src="images/advisors/taylor.jpg" alt="">
+                </a>
+              </div>
+              <div class="media-body">
+                <h4>Taylor Culver</h4>
+                <h5>Founder &amp; Principal Consultant XenoDATA Partners</h5>
+                <ul class="tag clearfix">
+                  <li class="btn">
+                    <a href="#">Data Strategy</a>
+                  </li>
+                  <li class="btn">
+                    <a href="#">Corporate Finance</a>
+                  </li>
+                  <li class="btn">
+                    <a href="#">Business Intelligence</a>
+                  </li>
+                </ul>
+                <ul class="social_icons">
+                  <li>
+                    <a href="https://www.linkedin.com/in/taylorculver/">
+                      <i class="fa fa-linkedin"></i>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <!--/.media -->
+            <p>Taylor Culver has spent the past 10 years developing an expertise in leveraging data across the enterprise. Across
+              multiple successful projects across multiple industries, Taylor has lead successful strategic intiatives and
+              have implemented technologies that have solved critical operational, financial, and client issues while raising
+              the bar for organizational strategy and managing data as a strategic asset.</p>
+          </div>
+        </div>
+      </div>
+      <!--/.our-skill-->
+
+      <!-- our-team -->
+      <div class="team">
+        <div class="center wow fadeInDown">
+          <h2>Advisory Board</h2>
+          <p class="lead">XenoDATA Partners are proud to bring in house advice that spans multiple domains and industries, all unified by
+            a passion for solving organizational issues with data.</p>
+        </div>
+
+        <div class="col-md-6 col-lg-4">
+          <div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
+            <div class="media">
+              <div class="pull-left">
+                <a href="#">
+                  <img class="media-object" src="images/advisors/ozel.jpg" alt="">
+                </a>
+              </div>
+              <div class="media-body">
+                <h4>Ozel Christo</h4>
+                <h5>CEO &amp; Founder of Neokami</h5>
+                <ul class="tag clearfix">
+                  <li class="btn">
+                    <a href="#">Artificial Inteligence</a>
+                  </li>
+                  <li class="btn">
+                    <a href="#">Machine Learning</a>
+                  </li>
+                  <li class="btn">
+                    <a href="#">Data Visualization</a>
+                  </li>
+                </ul>
+                <ul class="social_icons">
+                  <li>
+                    <a href="https://www.linkedin.com/in/ozelchristo/">
+                      <i class="fa fa-linkedin"></i>
+                    </a>
+                  </li>
+                  <li>
+                    <a href="https://twitter.com/ozelchristo?lang=en">
+                      <i class="fa fa-twitter"></i>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <!--/.media -->
+            <p>Experienced entrepreneur and computer scientist. Prior to founding Neokami, studied Computational Science and
+              Engineering at the Technical University of Munich and worked as a machine learning software developer at several
+              start-ups. Ozel has 17 years of algorithm design, coding and implementation experience.</p>
+          </div>
+        </div>
+
+        <div class="col-md-6 col-lg-4">
+          <div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
+            <div class="media">
+              <div class="pull-left">
+                <a href="#">
+                  <img class="media-object" src="images/advisors/reuben.jpg" alt="">
+                </a>
+              </div>
+              <div class="media-body">
+                <h4>Reuben Vandeventer</h4>
+                <h5>Founder &amp; CEO Data Clairvoyance</h5>
+                <ul class="tag clearfix">
+                  <li class="btn">
+                    <a href="#">Data Monetization</a>
+                  </li>
+                  <li class="btn">
+                    <a href="#">Data Strategy</a>
+                  </li>
+                  <li class="btn">
+                    <a href="#">Data Governance</a>
+                  </li>
+                </ul>
+                <ul class="social_icons">
+                  <li>
+                    <a href="https://www.linkedin.com/in/ozelchristo/">
+                      <i class="fa fa-linkedin"></i>
+                    </a>
+                  </li>
+                  <li>
+                    <a href="https://twitter.com/rjvandeve?lang=en">
+                      <i class="fa fa-twitter"></i>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <!--/.media -->
+            <p>Mr. Vandeventer has been driving progress and helping to shape the data space for more than a decade, across
+              many industries including Medical Device, Pharmaceutical, Insurance and Asset Management. His background in
+              science, statistics and finance has created a robust foundation to create real economic value for organizations
+              in new and innovative ways.</p>
+          </div>
+        </div>
+
+        <div class="col-md-6 col-lg-4">
+          <div class="single-profile-top wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
+            <div class="media">
+              <div class="pull-left">
+                <a href="http://innerpowerintl.com/debbie-himsel/">
+                  <img class="media-object" src="images/advisors/debbie.jpg" alt="">
+                </a>
+              </div>
+              <div class="media-body">
+                <h4>Deborah Himsel</h4>
+                <h5>President Himsel &amp; and Associates</h5>
+                <ul class="tag clearfix">
+                  <li class="btn">
+                    <a href="#">Change Management</a>
+                  </li>
+                  <li class="btn">
+                    <a href="#">Executive Coaching</a>
+                  </li>
+                  <li class="btn">
+                    <a href="#">Organizational Developement</a>
+                  </li>
+                </ul>
+
+                <ul class="social_icons">
+                  <li>
+                    <a href="#">
+                      <i class="fa fa-linkedin"></i>
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#">
+                      <i class="fa fa-twitter"></i>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <!--/.media -->
+            <p>Deborrah M. Himsel is a recognized expert in leadership development, a change agent, a thought leader, an author,
+              an educator and executive coach…a sought-after speaker for conferences and workshops.</p>
+          </div>
+        </div>
+
+        <div class="col-md-6 col-lg-4">
+          <div class="single-profile-bottom wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
+            <div class="media">
+              <div class="pull-left">
+                <a href="#">
+                  <img class="media-object" src="images/advisors/bill.jpg" alt="">
+                </a>
+              </div>
+              <div class="media-body">
+                <h4>William D. Gilbride, Jr.</h4>
+                <h5>Managing Shareholder and CEO at Abbott Nicholson</h5>
+                <ul class="tag clearfix">
+                  <li class="btn">
+                    <a href="#">Corporate Law</a>
+                  </li>
+                  <li class="btn">
+                    <a href="#">Dispute Avoidance</a>
+                  </li>
+                  <li class="btn">
+                    <a href="#">Conflict Resolution</a>
+                  </li>
+                </ul>
+                <ul class="social_icons">
+                  <li>
+                    <a href="https://www.linkedin.com/in/william-d-gilbride-jr-b9636a1a/">
+                      <i class="fa fa-linkedin"></i>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <!--/.media -->
+            <p>Bill has over 30 years of experience representing business interests in contracts, business and corporate law,
+              dispute avoidance and resolution, real estate, zoning and land use law. Bill has been approved as outside counsel
+              for Ascension Health; Amazon; Kettering University; Northern Trust Bank; Rockwell Automation; SmithGroupJJR;
+              St John Providence Health System; and US Bank.</p>
+          </div>
+        </div>
+
+        <div class="col-md-6 col-lg-4">
+          <div class="single-profile-bottom wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
+            <div class="media">
+              <div class="pull-left">
+                <a href="#">
+                  <img class="media-object" src="images/advisors/kyle.jpg" alt="">
+                </a>
+              </div>
+              <div class="media-body">
+                <h4>Kyle Scott</h4>
+                <h5>Vice President, Finance at HercRentals</h5>
+                <ul class="tag clearfix">
+                  <li class="btn">
+                    <a href="#">Corporate Finance</a>
+                  </li>
+                  <li class="btn">
+                    <a href="#">FP&amp;A</a>
+                  </li>
+                  <li class="btn">
+                    <a href="#">Operations</a>
+                  </li>
+                </ul>
+
+                <ul class="social_icons">
+                  <li>
+                    <a href="#">
+                      <i class="fa fa-linkedin"></i>
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#">
+                      <i class="fa fa-twitter"></i>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <!--/.media -->
+            <p>Current Vice President of Finance and former CFO of Hertz Europe, Kyle is a leader in driving sales and operational
+              results with data.</p>
+          </div>
+        </div>
+
+        <div class="col-md-6 col-lg-4">
+          <div class="single-profile-bottom wow fadeInDown" data-wow-duration="1000ms" data-wow-delay="300ms">
+            <div class="media">
+              <div class="pull-left">
+                <a href="#">
+                  <img class="media-object" src="images/advisors/tristan.jpg" alt="">
+                </a>
+              </div>
+              <div class="media-body">
+                <h4>Tristan Blakely</h4>
+                <h5>Founder, Dreamtek &amp; Partner @ The Virtual Forge</h5>
+                <ul class="tag clearfix">
+                  <li class="btn">
+                    <a href="#">Content Production</a>
+                  </li>
+                  <li class="btn">
+                    <a href="#">Marketing</a>
+                  </li>
+                  <li class="btn">
+                    <a href="#">Product Development</a>
+                  </li>
+                </ul>
+
+                <ul class="social_icons">
+                  <li>
+                    <a href="https://www.linkedin.com/in/tristan-blakley-361a545/">
+                      <i class="fa fa-linkedin"></i>
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#">
+                      <i class="fa fa-twitter"></i>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <!--/.media -->
+            <p>Tech entrepreneur specialising in providing data-centric solutions for large enterprise &amp; StartUps leveraging
+              Artificial Intelligence &amp; Machine Learning</p>
+          </div>
+        </div>
+
+      </div>
+      <!--Team -->
+    </div>
+    <!--Container -->
+  </section>
+  <!--/about-us.html-->
+
+  <section id="bottom">
+    <div class="container">
+      <div class="row">
+        <div class="col-md-3 col-xs-12">
+          <div class="widget">
+            <h3>Company</h3>
+            <ul>
+              <li>
+                <a href="about-us.html">About Us</a>
+              </li>
+              <li>
+                <a href="about-us.html">Meet the Team</a>
+              </li>
+              <li>
+                <a href="contact-us.html">Contact Us</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <!--/.col-md-3-->
+
+        <div class="col-md-3 col-xs-12">
+          <div class="widget">
+            <h3>Services</h3>
+            <ul>
+              <li>
+                <a href="services.html">Overview</a>
+              </li>
+              <li>
+                <a href="services.html">Methodology</a>
+              </li>
+              <li>
+                <a href="services.html">Client Personas</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <!--/.col-md-3-->
+
+        <div class="col-md-3 col-xs-12">
+          <div class="widget">
+            <h3>Our Partners</h3>
+            <ul>
+              <li>
+                <a href="partners.html">The Virtual Forge</a>
+              </li>
+              <li>
+                <a href="partners.html">ThoughtSpot</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <!--/.col-md-3-->
+      </div>
+    </div>
+  </section>
+  <!--/#bottom-->
+
+  <footer id="footer" class="midnight-blue">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-6">
+          &copy; 2018
+          <a target="_blank" href="http://shapebootstrap.net/" title="Free Twitter Bootstrap WordPress Themes and HTML templates">Culver Global Holdings</a>. All Rights Reserved.
+        </div>
+        <div class="col-sm-6">
+          <ul class="pull-right">
+            <li>
+              <a href="index.html">Home</a>
+            </li>
+            <li>
+              <a href="about-us.html">About Us</a>
+            </li>
+            <li>
+              <a href="contact-us.html">Contact Us</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <!--/#footer-->
+
+  <script src="js/jquery.js"></script>
+  <script src="js/bootstrap.min.js"></script>
+  <script src="js/jquery.prettyPhoto.js"></script>
+  <script src="js/jquery.isotope.min.js"></script>
+  <script src="js/main.js"></script>
+  <script src="js/wow.min.js"></script>
 </body>
+
 </html>

--- a/css/main.css
+++ b/css/main.css
@@ -1017,6 +1017,30 @@ a.accordion-toggle  i{
 ********* About Us Page CSS ******
 **************************/
 
+.row.leadership-team {
+  display: flex;
+  justify-content: center;
+  margin-top: -40px;
+}
+
+.advisory-header {
+  padding-bottom: 40px;
+}
+
+.team .single-profile-top,
+.team .single-profile-bottom {
+  margin-bottom: 30px;
+  max-width: 750px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+p.section-description {
+  max-width: 80rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .about-us {
   margin-top: 110px;
   margin-bottom: -110px;
@@ -1180,7 +1204,7 @@ a.accordion-toggle  i{
 .skill-wrap {
   display: block;
   overflow: hidden;
-  margin: 60px 0;
+  margin: 0 0 60px;
 }
 
 .team h4 {

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -267,11 +267,6 @@
     margin-bottom: 30px;
   }
 
-  .team .single-profile-top,
-  .team .single-profile-bottom {
-    margin-bottom: 30px;
-  }
-
   .clients-area {
     padding: 60px 0;
   }
@@ -325,5 +320,12 @@
 @media(max-width: 768px){
   #main-slider .carousel .slide-margin {
     height: 50vh;
+  }
+}
+
+/* Up to large */
+@media(max-width: 1200px){
+  .team .media {
+    margin-bottom: 15px;
   }
 }


### PR DESCRIPTION
# What was done
* Cleans up display of Advisory board cards
* Centers leadership team card and makes it wider than the others at the medium breakpoint
* “Beautifies” the about-us.html file (now 2 spaces)

## Finishes
[#157613717](https://www.pivotaltracker.com/story/show/157613717)

## Screenshots
### Deskto
![about-us-desktop](https://user-images.githubusercontent.com/903898/40263693-1ac4dbda-5acb-11e8-8515-9012ee4b7d0f.png)
p

### Medium
![about-us-md](https://user-images.githubusercontent.com/903898/40263694-1d1050c2-5acb-11e8-9776-29a3f6ba937f.png)

### Mobile
![about-us-mobile](https://user-images.githubusercontent.com/903898/40263695-1f99a7e4-5acb-11e8-9b42-391ec599b284.png)
