### PR TITLE
Fix contact form action

### DIFF
--- a/contact-us.html
+++ b/contact-us.html
@@ -138,11 +138,7 @@
       </div>
       <div class="row contact-wrap">
         <div id="contact-form-alert-success" class="status alert alert-success" style="display: none;"></div>
-<!-- <<<<<<< Updated upstream -->
         <form id="main-contact-form" class="contact-form" name="contact-form" method="post" action="https://sxhq4xwi14.execute-api.us-east-1.amazonaws.com/production/contacthtml" data-api-key="TfblAS4c6o7zAeimJyqRh4pVCKU1YVg07wbDj9bE">
-<!-- ======= -->
-          <form id="main-contact-form" class="contact-form" name="contact-form" method="post" action="https://gxoa4ipgmb.execute-api.us-east-1.amazonaws.com/staging/contacthtml" data-api-key="4FsoRWTvUo2JC9hPW2IcF1ip9zAcWyWi6iqgaEa8">
-<!-- >>>>>>> Stashed changes -->
           <div class="col-sm-5 col-sm-offset-1">
             <div class="form-group">
               <label>Name *</label>


### PR DESCRIPTION
A git merge conflict resulted in multiple `<form>` tags being present on the contact page. This removes the extra content and uses the correct endpoint.

Finishes [#159843076](https://www.pivotaltracker.com/story/show/159843076)